### PR TITLE
add strong red badge color

### DIFF
--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -134,14 +134,16 @@ func coverageColor(coverage int) string {
 	//nolint:gomnd // relax
 	switch {
 	case coverage >= 100:
-		return "#44cc11" // green
+		return "#44cc11" // strong green
 	case coverage >= 90:
 		return "#97ca00" // light green
 	case coverage >= 80:
 		return "#dfb317" // yellow
 	case coverage >= 70:
 		return "#fa7739" // orange
+	case coverage >= 50:
+		return "#e05d44" // light red
 	default:
-		return "#e05d44" // red
+		return "#cb2431" // strong red
 	}
 }

--- a/pkg/testcoverage/report_test.go
+++ b/pkg/testcoverage/report_test.go
@@ -207,7 +207,7 @@ func Test_CoverageColor(t *testing.T) {
 			colors[color] = struct{}{}
 		}
 
-		assert.Len(t, colors, 5)
+		assert.Len(t, colors, 6)
 	}
 
 	{ // Assert valid color values


### PR DESCRIPTION
When coverage is below 50% badge color will have strong/critical color.