### PR TITLE
go version bump (v1.21)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.54.2
       - name: go mod tidy check
         uses: katexochen/go-tidy-check@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     # - godot (too nit picking)
     # - ireturn  (we like when function returns interface)
     # - varnamelen  (we can handle this in code review step)
+    # - depguard (not needed)
     - asasalint
     - asciicheck
     - bidichk
@@ -15,7 +16,6 @@ linters:
     - containedctx
     - contextcheck
     - cyclop
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GO ?= go
 GOBIN ?= $$($(GO) env GOPATH)/bin
 GOLANGCI_LINT ?= $(GOBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.51.2
+GOLANGCI_LINT_VERSION ?= v1.54.2
 
 .PHONY: get-golangcilint
 get-golangcilint:

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/vladopajic/go-test-coverage/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/alexflint/go-arg v1.4.3
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/tools v0.5.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+	golang.org/x/tools v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
-golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
+golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/tools v0.14.0 h1:jvNa2pY0M4r62jkRQ6RwEZZyPcymeL9XZMLBbV7U2nc=
+golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/testcoverage/types.go
+++ b/pkg/testcoverage/types.go
@@ -2,6 +2,8 @@ package testcoverage
 
 import (
 	"strings"
+
+	"golang.org/x/exp/maps"
 )
 
 type AnalyzeResult struct {
@@ -93,12 +95,7 @@ func makePackageStats(coverageStats []CoverageStats) []CoverageStats {
 		packageStats[pkg] = pkgStats
 	}
 
-	packageStatsSlice := make([]CoverageStats, 0, len(packageStats))
-	for _, stats := range packageStats {
-		packageStatsSlice = append(packageStatsSlice, stats)
-	}
-
-	return packageStatsSlice
+	return maps.Values(packageStats)
 }
 
 func packageForFile(filename string) string {


### PR DESCRIPTION
- go version bump (v1.21)
- golangcilint version bump (v1.54.2)