### PR TITLE
add ability to exclude entire function from coverage statistics

### DIFF
--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -56,10 +56,8 @@ func GenerateCoverageStats(cfg Config) ([]Stats, error) {
 		}
 
 		s := coverageForFile(profile, funcs, comments)
-		if s.Total != 0 { // add only files that have source code
-			s.Name = noPrefixName
-			fileStats = append(fileStats, s)
-		}
+		s.Name = noPrefixName
+		fileStats = append(fileStats, s)
 	}
 
 	return fileStats, nil

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -124,6 +124,7 @@ func Test_findComments(t *testing.T) {
 		return a
 	}
 	`
+
 	comments, err := FindComments([]byte(source))
 	assert.NoError(t, err)
 	assert.Equal(t, []int{3, 5}, pluckStartLine(comments))
@@ -148,6 +149,7 @@ func Test_findFuncs(t *testing.T) {
 		return 1
 	}
 	`
+
 	funcs, err := FindFuncs([]byte(source))
 	assert.NoError(t, err)
 	assert.Equal(t, []int{3, 7}, pluckStartLine(funcs))

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -115,19 +115,18 @@ func Test_findComments(t *testing.T) {
 	assert.Error(t, err)
 
 	const source = `
-		package foo
-
-		func foo() int { // coverage-ignore
-			a := 0
-			for i := range 10 { // coverage-ignore
-				a += i
-			}
-			return a
+	package foo
+	func foo() int { // coverage-ignore
+		a := 0
+		for i := range 10 { // coverage-ignore
+			a += i
 		}
+		return a
+	}
 	`
 	comments, err := FindComments([]byte(source))
 	assert.NoError(t, err)
-	assert.Equal(t, []int{4, 6}, pluckStartLine(comments))
+	assert.Equal(t, []int{3, 5}, pluckStartLine(comments))
 }
 
 func Test_findFuncs(t *testing.T) {
@@ -141,19 +140,17 @@ func Test_findFuncs(t *testing.T) {
 
 	const source = `
 	package foo
-
 	func foo() int {
 		a := 0
 		return a
 	}
-
 	func bar() int {
 		return 1
 	}
 	`
 	funcs, err := FindFuncs([]byte(source))
 	assert.NoError(t, err)
-	assert.Equal(t, []int{4, 9}, pluckStartLine(funcs))
+	assert.Equal(t, []int{3, 7}, pluckStartLine(funcs))
 }
 
 func Test_coverageForFile(t *testing.T) {

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -1,10 +1,11 @@
 package coverage
 
 var (
-	FindFile      = findFile
-	FindComments  = findComments
-	FindFuncs     = findFuncs
-	ParseProfiles = parseProfiles
+	FindFile        = findFile
+	FindComments    = findComments
+	FindFuncs       = findFuncs
+	ParseProfiles   = parseProfiles
+	CoverageForFile = coverageForFile
 )
 
 type Extent = extent


### PR DESCRIPTION
- if function has `coverage-ignore` annotation it will be excluded from coverage statistics as whole