### PR TITLE
fixed ThresholdTotal value check

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func (a *args) overrideConfig(cfg testcoverage.Config) (testcoverage.Config, err
 		cfg.Threshold.Package = a.ThresholdPackage
 	}
 
-	if !isCIDefaultInt(a.ThresholdPackage) {
+	if !isCIDefaultInt(a.ThresholdTotal) {
 		cfg.Threshold.Total = a.ThresholdTotal
 	}
 


### PR DESCRIPTION
If ThresholdPackage argument was not set, ThresholdTotal argument was ignored.