### PR TITLE
fix: evaluation of boolean conditions in github workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
           git-branch: badges
           git-token: ${{ github.ref_name == 'main' && secrets.GITHUB_TOKEN || '' }}
           breakdown-file-name: ${{ github.ref_name == 'main' && 'main.breakdown' || '' }}
-          diff-base-breakdown-file-name: ${{ steps.download-main-breakdown.outputs.found_artifact && 'main.breakdown' || '' }}
+          diff-base-breakdown-file-name: ${{ steps.download-main-breakdown.outputs.found_artifact == 'true' && 'main.breakdown' || '' }}
  
       - name: upload artifact (main.breakdown)
         uses: actions/upload-artifact@v4

--- a/docs/github_action.md
+++ b/docs/github_action.md
@@ -83,7 +83,7 @@ Example of report that includes coverage difference is [this PR](https://github.
 
       # If this is not main brach we want to show report including
       # file coverage difference from main branch.
-      diff-base-breakdown-file-name: ${{ steps.download-main-breakdown.outputs.found_artifact && 'main.breakdown' || '' }}
+      diff-base-breakdown-file-name: ${{ steps.download-main-breakdown.outputs.found_artifact == 'true' && 'main.breakdown' || '' }}
     
   - name: upload artifact (main.breakdown)
     uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 📝 Description

This PR fixes the conditional for providing file name for `diff-base-breakdown-file-name` on the example provided, which was leading to always provide that value (even with that`main.breakdown` file is missing). The reason for this was that we were expecting a boolean output from the previous action and, unfortunately, even if the response is `false`, the conditional considers the value as string ([already known behavior](https://github.com/actions/runner/issues/1483)).

This PR simply checks that value as string and updates the documentation to display that change.

## 🔗 Related Issue

N/A

## ✅ Checklist Before Requesting a Review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] I have ensured that all tests pass locally.
- [x] I have followed the project's coding standards.

## 📋 Changes Summary

- Change 1: Added string comparison instead on example workflow `test.yml`
- Change 2: Updated documentation for github action on `github_action.md`

## 🚀 How to Test

I have tested the issue on my private repository too, so I can share some screenshots about it:

**Before the fix:**
![Screenshot 2025-01-02 at 16 59 34](https://github.com/user-attachments/assets/69d6692c-38a1-41ac-9697-c32e62918e80)
![Screenshot 2025-01-02 at 16 59 26](https://github.com/user-attachments/assets/781f99b7-cd09-46dd-90ee-bbdffa960a47)

**After the fix:**
![Screenshot 2025-01-02 at 16 59 58](https://github.com/user-attachments/assets/11b3c148-7602-4739-9454-f2a2e38a22b5)
![Screenshot 2025-01-02 at 17 00 06](https://github.com/user-attachments/assets/ae9bbd1d-de64-42ae-9ea0-7ad1faa55c20)


## 🛠️ Additional Notes

Thanks so much for this project! I have been working with GO a few weeks so far, and this has been a nice repository to use ❤️ 