### PR TITLE
Implemented caching in method findFile

### DIFF
--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -17,12 +17,44 @@ import (
 
 const IgnoreText = "coverage-ignore"
 
-var buildCache = make(map[string]*build.Package)
-
 type Config struct {
 	Profiles     []string
 	LocalPrefix  string
 	ExcludePaths []string
+}
+
+func findFileCreator() func(file, prefix string) (string, string, error) {
+	cache := make(map[string]*build.Package)
+
+	return func(file, prefix string) (string, string, error) {
+		profileFile := file
+
+		noPrefixName := stripPrefix(file, prefix)
+		if _, err := os.Stat(noPrefixName); err == nil { // coverage-ignore
+			return noPrefixName, noPrefixName, nil
+		}
+
+		dir, file := filepath.Split(file)
+		pkg, exists := cache[dir]
+
+		if !exists {
+			var err error
+
+			pkg, err = build.Import(dir, ".", build.FindOnly)
+			if err != nil {
+				return "", "", fmt.Errorf("can't find file %q: %w", profileFile, err)
+			}
+
+			cache[dir] = pkg
+		}
+
+		file = filepath.Join(pkg.Dir, file)
+		if _, err := os.Stat(file); err == nil {
+			return file, stripPrefix(path.NormalizeForTool(file), path.NormalizeForTool(pkg.Root)), nil
+		}
+
+		return "", "", fmt.Errorf("can't find file %q", profileFile)
+	}
 }
 
 func GenerateCoverageStats(cfg Config) ([]Stats, error) {
@@ -31,6 +63,7 @@ func GenerateCoverageStats(cfg Config) ([]Stats, error) {
 		return nil, fmt.Errorf("parsing profiles: %w", err)
 	}
 
+	findFile := findFileCreator()
 	fileStats := make([]Stats, 0, len(profiles))
 	excludeRules := compileExcludePathRules(cfg.ExcludePaths)
 
@@ -72,35 +105,6 @@ func GenerateCoverageStats(cfg Config) ([]Stats, error) {
 	}
 
 	return fileStats, nil
-}
-
-// findFile finds the location of the named file in GOROOT, GOPATH etc.
-func findFile(file, prefix string) (string, string, error) {
-	profileFile := file
-
-	noPrefixName := stripPrefix(file, prefix)
-	if _, err := os.Stat(noPrefixName); err == nil { // coverage-ignore
-		return noPrefixName, noPrefixName, nil
-	}
-
-	dir, file := filepath.Split(file)
-
-	pkg, exists := buildCache[dir]
-	if !exists {
-		var err error
-		pkg, err = build.Import(dir, ".", build.FindOnly)
-		if err != nil {
-			return "", "", fmt.Errorf("can't find file %q: %w", profileFile, err)
-		}
-		buildCache[dir] = pkg
-	}
-
-	file = filepath.Join(pkg.Dir, file)
-	if _, err := os.Stat(file); err == nil {
-		return file, stripPrefix(path.NormalizeForTool(file), path.NormalizeForTool(pkg.Root)), nil
-	}
-
-	return "", "", fmt.Errorf("can't find file %q", profileFile)
 }
 
 func findAnnotations(source []byte) ([]extent, error) {

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -1,7 +1,7 @@
 package coverage
 
 var (
-	FindFile           = findFile
+	FindFile           = findFileCreator()
 	FindAnnotations    = findAnnotations
 	FindFuncsAndBlocks = findFuncsAndBlocks
 	ParseProfiles      = parseProfiles


### PR DESCRIPTION
Issue:
This package was starting to take ~5 mins to calculate coverage in a repo for us

Analysis:
Local debugging showed that findFile func is taking the longest. On average, its taking 200ms for one profile.

Solution:
Implemented caching in findFile func to store the pkg once it has been imported. This reduces the latency heavy call to build.Import for importing pkg for each profile

This package now takes 40 secs to finish in the same repo