### PR TITLE
report when overall threshold present (or) overrides are present

### DIFF
--- a/pkg/testcoverage/check.go
+++ b/pkg/testcoverage/check.go
@@ -75,10 +75,11 @@ func GenerateCoverageStats(cfg Config) ([]coverage.Stats, error) {
 
 func Analyze(cfg Config, current, base []coverage.Stats) AnalyzeResult {
 	thr := cfg.Threshold
-	overrideRules := compileOverridePathRules(cfg)
+	overrideRules, hasOverrides := compileOverridePathRules(cfg)
 
 	return AnalyzeResult{
 		Threshold:           thr,
+		HasOverrides:        hasOverrides,
 		FilesBelowThreshold: checkCoverageStatsBelowThreshold(current, thr.File, overrideRules),
 		PackagesBelowThreshold: checkCoverageStatsBelowThreshold(
 			makePackageStats(current), thr.Package, overrideRules,

--- a/pkg/testcoverage/check.go
+++ b/pkg/testcoverage/check.go
@@ -74,14 +74,9 @@ func GenerateCoverageStats(cfg Config) ([]coverage.Stats, error) {
 }
 
 func Analyze(cfg Config, current, base []coverage.Stats) AnalyzeResult {
-	var hasFileOverrides, hasPackageOverrides bool
-
 	thr := cfg.Threshold
 	overrideRules := compileOverridePathRules(cfg)
-
-	if len(cfg.Override) > 0 {
-		hasFileOverrides, hasPackageOverrides = detectOverrides(cfg.Override)
-	}
+	hasFileOverrides, hasPackageOverrides := detectOverrides(cfg.Override)
 
 	return AnalyzeResult{
 		Threshold:           thr,
@@ -102,16 +97,10 @@ func detectOverrides(overrides []Override) (bool, bool) {
 	hasPackageOverrides := false
 
 	for _, override := range overrides {
-		if strings.HasSuffix(override.Path, ".go") {
+		if strings.HasSuffix(override.Path, ".go") || strings.HasSuffix(override.Path, ".go$") {
 			hasFileOverrides = true
-		}
-
-		if strings.HasPrefix(override.Path, "^") {
+		} else {
 			hasPackageOverrides = true
-		}
-
-		if hasFileOverrides && hasPackageOverrides {
-			return hasFileOverrides, hasPackageOverrides
 		}
 	}
 

--- a/pkg/testcoverage/check.go
+++ b/pkg/testcoverage/check.go
@@ -75,6 +75,7 @@ func GenerateCoverageStats(cfg Config) ([]coverage.Stats, error) {
 
 func Analyze(cfg Config, current, base []coverage.Stats) AnalyzeResult {
 	var hasFileOverrides, hasPackageOverrides bool
+
 	thr := cfg.Threshold
 	overrideRules := compileOverridePathRules(cfg)
 
@@ -96,19 +97,25 @@ func Analyze(cfg Config, current, base []coverage.Stats) AnalyzeResult {
 	}
 }
 
-func detectOverrides(overrides []Override) (hasFileOverrides, hasPackageOverrides bool) {
+func detectOverrides(overrides []Override) (bool, bool) {
+	hasFileOverrides := false
+	hasPackageOverrides := false
+
 	for _, override := range overrides {
 		if strings.HasSuffix(override.Path, ".go") {
 			hasFileOverrides = true
 		}
+
 		if strings.HasPrefix(override.Path, "^") {
 			hasPackageOverrides = true
 		}
+
 		if hasFileOverrides && hasPackageOverrides {
-			return // Early return if both found
+			return hasFileOverrides, hasPackageOverrides
 		}
 	}
-	return
+
+	return hasFileOverrides, hasPackageOverrides
 }
 
 func saveCoverageBreakdown(cfg Config, stats []coverage.Stats) error {

--- a/pkg/testcoverage/check_test.go
+++ b/pkg/testcoverage/check_test.go
@@ -118,7 +118,7 @@ func TestCheck(t *testing.T) {
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
 		assertGithubActionErrorsCount(t, buf.String(), 0)
-		assertHumanReport(t, buf.String(), 1, 0)
+		assertHumanReport(t, buf.String(), 2, 0)
 		assert.GreaterOrEqual(t, strings.Count(buf.String(), prefix), 0)
 	})
 
@@ -134,7 +134,7 @@ func TestCheck(t *testing.T) {
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
 		assertGithubActionErrorsCount(t, buf.String(), 0)
-		assertHumanReport(t, buf.String(), 0, 1)
+		assertHumanReport(t, buf.String(), 0, 2)
 		assert.GreaterOrEqual(t, strings.Count(buf.String(), prefix), 0)
 	})
 

--- a/pkg/testcoverage/check_test.go
+++ b/pkg/testcoverage/check_test.go
@@ -138,6 +138,38 @@ func TestCheck(t *testing.T) {
 		assert.GreaterOrEqual(t, strings.Count(buf.String(), prefix), 0)
 	})
 
+	t.Run("valid profile - pass after file override", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		cfg := Config{
+			Profile:   profileOK,
+			Threshold: Threshold{File: 70},
+			Override:  []Override{{Threshold: 60, Path: "pkg/testcoverage/badgestorer/github.go"}},
+		}
+		pass := Check(buf, cfg)
+		assert.True(t, pass)
+		assertGithubActionErrorsCount(t, buf.String(), 0)
+		assertHumanReport(t, buf.String(), 1, 0)
+		assert.GreaterOrEqual(t, strings.Count(buf.String(), prefix), 0)
+	})
+
+	t.Run("valid profile - fail after file override", func(t *testing.T) {
+		t.Parallel()
+
+		buf := &bytes.Buffer{}
+		cfg := Config{
+			Profile:   profileOK,
+			Threshold: Threshold{File: 70},
+			Override:  []Override{{Threshold: 80, Path: "pkg/testcoverage/badgestorer/github.go"}},
+		}
+		pass := Check(buf, cfg)
+		assert.False(t, pass)
+		assertGithubActionErrorsCount(t, buf.String(), 0)
+		assertHumanReport(t, buf.String(), 0, 1)
+		assert.GreaterOrEqual(t, strings.Count(buf.String(), prefix), 0)
+	})
+
 	t.Run("valid profile - fail couldn't save badge", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -36,14 +36,14 @@ func reportCoverage(w io.Writer, result AnalyzeResult) {
 
 	thr := result.Threshold
 
-	if thr.File > 0 { // File threshold report
+	if thr.File > 0 || result.HasOverrides { // File threshold report
 		fmt.Fprintf(tabber, "File coverage threshold (%d%%) satisfied:\t", thr.File)
 		fmt.Fprint(tabber, statusStr(len(result.FilesBelowThreshold) == 0))
 		reportIssuesForHuman(tabber, result.FilesBelowThreshold)
 		fmt.Fprint(tabber, "\n")
 	}
 
-	if thr.Package > 0 { // Package threshold report
+	if thr.Package > 0 || result.HasOverrides { // Package threshold report
 		fmt.Fprintf(tabber, "Package coverage threshold (%d%%) satisfied:\t", thr.Package)
 		fmt.Fprint(tabber, statusStr(len(result.PackagesBelowThreshold) == 0))
 		reportIssuesForHuman(tabber, result.PackagesBelowThreshold)

--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -36,14 +36,14 @@ func reportCoverage(w io.Writer, result AnalyzeResult) {
 
 	thr := result.Threshold
 
-	if thr.File > 0 || result.HasOverrides { // File threshold report
+	if thr.File > 0 || result.HasFileOverrides { // File threshold report
 		fmt.Fprintf(tabber, "File coverage threshold (%d%%) satisfied:\t", thr.File)
 		fmt.Fprint(tabber, statusStr(len(result.FilesBelowThreshold) == 0))
 		reportIssuesForHuman(tabber, result.FilesBelowThreshold)
 		fmt.Fprint(tabber, "\n")
 	}
 
-	if thr.Package > 0 || result.HasOverrides { // Package threshold report
+	if thr.Package > 0 || result.HasPackageOverrides { // Package threshold report
 		fmt.Fprintf(tabber, "Package coverage threshold (%d%%) satisfied:\t", thr.Package)
 		fmt.Fprint(tabber, statusStr(len(result.PackagesBelowThreshold) == 0))
 		reportIssuesForHuman(tabber, result.PackagesBelowThreshold)

--- a/pkg/testcoverage/types.go
+++ b/pkg/testcoverage/types.go
@@ -15,6 +15,7 @@ type AnalyzeResult struct {
 	TotalStats             coverage.Stats
 	HasBaseBreakdown       bool
 	Diff                   []FileCoverageDiff
+	HasOverrides           bool
 }
 
 func (r *AnalyzeResult) Pass() bool {

--- a/pkg/testcoverage/types.go
+++ b/pkg/testcoverage/types.go
@@ -15,7 +15,8 @@ type AnalyzeResult struct {
 	TotalStats             coverage.Stats
 	HasBaseBreakdown       bool
 	Diff                   []FileCoverageDiff
-	HasOverrides           bool
+	HasFileOverrides       bool
+	HasPackageOverrides    bool
 }
 
 func (r *AnalyzeResult) Pass() bool {

--- a/pkg/testcoverage/utils.go
+++ b/pkg/testcoverage/utils.go
@@ -19,9 +19,9 @@ func matches(regexps []regRule, str string) (int, bool) {
 	return 0, false
 }
 
-func compileOverridePathRules(cfg Config) []regRule {
+func compileOverridePathRules(cfg Config) ([]regRule, bool) {
 	if len(cfg.Override) == 0 {
-		return nil
+		return nil, false
 	}
 
 	compiled := make([]regRule, len(cfg.Override))
@@ -33,5 +33,5 @@ func compileOverridePathRules(cfg Config) []regRule {
 		}
 	}
 
-	return compiled
+	return compiled, true
 }

--- a/pkg/testcoverage/utils.go
+++ b/pkg/testcoverage/utils.go
@@ -19,9 +19,9 @@ func matches(regexps []regRule, str string) (int, bool) {
 	return 0, false
 }
 
-func compileOverridePathRules(cfg Config) ([]regRule, bool) {
+func compileOverridePathRules(cfg Config) []regRule {
 	if len(cfg.Override) == 0 {
-		return nil, false
+		return nil
 	}
 
 	compiled := make([]regRule, len(cfg.Override))
@@ -33,5 +33,5 @@ func compileOverridePathRules(cfg Config) ([]regRule, bool) {
 		}
 	}
 
-	return compiled, true
+	return compiled
 }


### PR DESCRIPTION
Changes: 
Allow reports of pkg and file level overrides even when overall pkg and file thresholds are 0

Closes: #140 