### PR TITLE
fix: add rounding of percentage

### DIFF
--- a/pkg/testcoverage/coverage/types.go
+++ b/pkg/testcoverage/coverage/types.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -64,7 +65,10 @@ func coveredPercentageF(total, covered int64) float64 {
 		return 100
 	}
 
-	return float64(covered*100) / float64(total)
+	p := float64(covered*100) / float64(total)
+
+	// round to %.1f
+	return float64(int(math.Round(p*10))) / 10
 }
 
 func stripPrefix(name, prefix string) string {

--- a/pkg/testcoverage/coverage/types_test.go
+++ b/pkg/testcoverage/coverage/types_test.go
@@ -22,6 +22,7 @@ func TestCoveredPercentage(t *testing.T) {
 		{percentage: 10, total: 10, covered: 1},
 		{percentage: 22, total: 9, covered: 2}, // 22.222.. should round down to 22
 		{percentage: 66, total: 9, covered: 6}, // 66.666.. should round down to 66
+		{percentage: 73, total: 274, covered: 200},
 	}
 
 	for _, tc := range tests {
@@ -35,6 +36,7 @@ func TestStatStr(t *testing.T) {
 	assert.Equal(t, " 0.0% (0/0)", Stats{}.Str())
 	assert.Equal(t, " 9.1% (1/11)", Stats{Covered: 1, Total: 11}.Str())
 	assert.Equal(t, "22.2% (2/9)", Stats{Covered: 2, Total: 9}.Str())
+	assert.Equal(t, "73.0% (200/274)", Stats{Covered: 200, Total: 274}.Str())
 	assert.Equal(t, "100% (10/10)", Stats{Covered: 10, Total: 10}.Str())
 }
 


### PR DESCRIPTION
this pr fixes discrepancy issue when percentage was show in report and used inside code. 

before, percentage in report was show as rounded value to 1 decimal point and when percentage was used in code it was truncated to integer value. this can cause issues like in #144. 

to address this when percentage is calculated it will be rounded to 1 decimal point in order.

Closes: #144