### PR TITLE
feat: add source dir optional configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,12 @@ inputs:
     required: false
     default: ""
     type: string
-  
+  source-dir:
+    description: Sets relative path to source files.
+    required: false
+    default: ""
+    type: string
+
   # Individual properties
   profile:
     description: Path to the coverage profile file. Overrides value from configuration.
@@ -132,6 +137,7 @@ runs:
   args:
     - --config=${{ inputs.config || '''''' }}
     - --profile=${{ inputs.profile || '''''' }}
+    - --source-dir=${{ inputs.source-dir || '''''' }}
     - --github-action-output=true
     - --threshold-file=${{ inputs.threshold-file }}
     - --threshold-package=${{ inputs.threshold-package }}

--- a/docs/github_action.md
+++ b/docs/github_action.md
@@ -38,6 +38,19 @@ Alternatively, if you don't need advanced configuration options from a config fi
 
 Note: When using a config file alongside action properties, specifying these parameters will override the corresponding values in the config file.
 
+## Source Directory
+
+Some projects, such as monorepos with multiple projects under the root directory, may require specifying the path to a project's source.
+In such cases, the `source-dir` property can be used to specify the source files location relative to the root directory.
+
+```yml
+  - name: check test coverage
+    uses: vladopajic/go-test-coverage@v2
+    with:
+      config: ./.testcoverage.yml
+      source-dir: ./some_project
+```
+
 ## Liberal Coverage Check
 
 The `go-test-coverage` GitHub Action can be configured to report the current test coverage without enforcing specific thresholds. To enable this functionality in your GitHub workflow, include the `continue-on-error: true` property in the job step configuration. This ensures that the workflow proceeds even if the coverage check fails.

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ type args struct {
 	ConfigPath         string `arg:"-c,--config"`
 	Profile            string `arg:"-p,--profile"              help:"path to coverage profile"`
 	LocalPrefix        string `arg:"-l,--local-prefix"` // deprecated
+	SourceDir          string `arg:"-s,--source-dir"`
 	GithubActionOutput bool   `arg:"-o,--github-action-output"`
 	ThresholdFile      int    `arg:"-f,--threshold-file"`
 	ThresholdPackage   int    `arg:"-k,--threshold-package"`
@@ -56,6 +57,7 @@ func newArgs() args {
 		ConfigPath:         ciDefaultString,
 		Profile:            ciDefaultString,
 		LocalPrefix:        ciDefaultString,
+		SourceDir:          ciDefaultString,
 		GithubActionOutput: false,
 		ThresholdFile:      ciDefaultInt,
 		ThresholdPackage:   ciDefaultInt,
@@ -100,6 +102,10 @@ func (a *args) overrideConfig(cfg testcoverage.Config) (testcoverage.Config, err
 
 	if !isCIDefaultString(a.LocalPrefix) {
 		cfg.LocalPrefixDeprecated = a.LocalPrefix
+	}
+
+	if !isCIDefaultString(a.SourceDir) {
+		cfg.SourceDir = a.SourceDir
 	}
 
 	if !isCIDefaultInt(a.ThresholdFile) {

--- a/pkg/testcoverage/check.go
+++ b/pkg/testcoverage/check.go
@@ -74,7 +74,7 @@ func GenerateCoverageStats(cfg Config) ([]coverage.Stats, error) {
 	return coverage.GenerateCoverageStats(coverage.Config{ //nolint:wrapcheck // err wrapped above
 		Profiles:     strings.Split(cfg.Profile, ","),
 		ExcludePaths: cfg.Exclude.Paths,
-		RootDir:      cfg.RootDir,
+		SourceDir:    cfg.SourceDir,
 	})
 }
 

--- a/pkg/testcoverage/check_test.go
+++ b/pkg/testcoverage/check_test.go
@@ -22,8 +22,8 @@ const (
 	breakdownOK  = testdataDir + testdata.BreakdownOK
 	breakdownNOK = testdataDir + testdata.BreakdownNOK
 
-	prefix  = "github.com/vladopajic/go-test-coverage/v2"
-	rootDir = "../../"
+	prefix    = "github.com/vladopajic/go-test-coverage/v2"
+	sourceDir = "../../"
 )
 
 func TestCheck(t *testing.T) {
@@ -60,7 +60,7 @@ func TestCheck(t *testing.T) {
 		t.Parallel()
 
 		buf := &bytes.Buffer{}
-		cfg := Config{Profile: profileOK, Threshold: Threshold{Total: 65}, RootDir: rootDir}
+		cfg := Config{Profile: profileOK, Threshold: Threshold{Total: 65}, SourceDir: sourceDir}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
 		assertGithubActionErrorsCount(t, buf.String(), 0)
@@ -79,7 +79,7 @@ func TestCheck(t *testing.T) {
 			Exclude: Exclude{
 				Paths: []string{`cdn\.go$`, `github\.go$`, `cover\.go$`, `check\.go$`, `path\.go$`},
 			},
-			RootDir: rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
@@ -92,7 +92,7 @@ func TestCheck(t *testing.T) {
 		t.Parallel()
 
 		buf := &bytes.Buffer{}
-		cfg := Config{Profile: profileOK, Threshold: Threshold{Total: 100}, RootDir: rootDir}
+		cfg := Config{Profile: profileOK, Threshold: Threshold{Total: 100}, SourceDir: sourceDir}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
 		assertGithubActionErrorsCount(t, buf.String(), 0)
@@ -113,7 +113,7 @@ func TestCheck(t *testing.T) {
 			Profile:   profileOK,
 			Threshold: Threshold{File: 100},
 			Override:  []Override{{Threshold: 10, Path: "^pkg"}},
-			RootDir:   rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
@@ -131,7 +131,7 @@ func TestCheck(t *testing.T) {
 			Profile:   profileOK,
 			Threshold: Threshold{File: 10},
 			Override:  []Override{{Threshold: 100, Path: "^pkg"}},
-			RootDir:   rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -153,7 +153,7 @@ func TestCheck(t *testing.T) {
 			Profile:   profileOK,
 			Threshold: Threshold{File: 70},
 			Override:  []Override{{Threshold: 60, Path: "pkg/testcoverage/badgestorer/github.go"}},
-			RootDir:   rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
@@ -171,7 +171,7 @@ func TestCheck(t *testing.T) {
 			Profile:   profileOK,
 			Threshold: Threshold{File: 70},
 			Override:  []Override{{Threshold: 80, Path: "pkg/testcoverage/badgestorer/github.go"}},
-			RootDir:   rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -195,7 +195,7 @@ func TestCheck(t *testing.T) {
 			Badge: Badge{
 				FileName: t.TempDir(), // should failed because this is dir
 			},
-			RootDir: rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -209,7 +209,7 @@ func TestCheck(t *testing.T) {
 		cfg := Config{
 			Profile:           profileOK,
 			BreakdownFileName: t.TempDir(), // should failed because this is dir
-			RootDir:           rootDir,
+			SourceDir:         sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -223,7 +223,7 @@ func TestCheck(t *testing.T) {
 		cfg := Config{
 			Profile:           profileOK,
 			BreakdownFileName: t.TempDir() + "/breakdown.testcoverage",
-			RootDir:           rootDir,
+			SourceDir:         sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
@@ -246,7 +246,7 @@ func TestCheck(t *testing.T) {
 			Diff: Diff{
 				BaseBreakdownFileName: t.TempDir(), // should failed because this is dir
 			},
-			RootDir: rootDir,
+			SourceDir: sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -268,7 +268,7 @@ func TestCheckNoParallel(t *testing.T) {
 			Profile:            profileOK,
 			GithubActionOutput: true,
 			Threshold:          Threshold{Total: 100},
-			RootDir:            rootDir,
+			SourceDir:          sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)
@@ -283,7 +283,7 @@ func TestCheckNoParallel(t *testing.T) {
 			Profile:            profileOK,
 			GithubActionOutput: true,
 			Threshold:          Threshold{Total: 10},
-			RootDir:            rootDir,
+			SourceDir:          sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.True(t, pass)
@@ -302,7 +302,7 @@ func TestCheckNoParallel(t *testing.T) {
 			Profile:            profileOK,
 			GithubActionOutput: true,
 			Threshold:          Threshold{Total: 100},
-			RootDir:            rootDir,
+			SourceDir:          sourceDir,
 		}
 		pass := Check(buf, cfg)
 		assert.False(t, pass)

--- a/pkg/testcoverage/config.go
+++ b/pkg/testcoverage/config.go
@@ -24,6 +24,7 @@ var (
 type Config struct {
 	Profile               string     `yaml:"profile"`
 	LocalPrefixDeprecated string     `yaml:"-"`
+	SourceDir             string     `yaml:"-"`
 	Threshold             Threshold  `yaml:"threshold"`
 	Override              []Override `yaml:"override,omitempty"`
 	Exclude               Exclude    `yaml:"exclude"`
@@ -31,7 +32,6 @@ type Config struct {
 	GithubActionOutput    bool       `yaml:"github-action-output"`
 	Diff                  Diff       `yaml:"diff"`
 	Badge                 Badge      `yaml:"-"`
-	RootDir               string     `yaml:"-"`
 }
 
 type Threshold struct {

--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -145,6 +145,7 @@ func findFileCreator(rootDir string) func(file string) (string, string, bool) {
 		return file, noPrefixName, err == nil
 	}
 
+	rootDir = defaultRootDir(rootDir)
 	prefix := findModuleDirective(rootDir)
 	files := listAllFiles(rootDir)
 	findWalk := func(file, prefix string) (string, string, bool) {
@@ -165,6 +166,14 @@ func findFileCreator(rootDir string) func(file string) (string, string, bool) {
 
 		return "", "", false
 	}
+}
+
+func defaultRootDir(rootDir string) string {
+	if rootDir == "" {
+		rootDir = "."
+	}
+
+	return rootDir
 }
 
 func listAllFiles(rootDir string) []fileInfo {

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -25,7 +25,7 @@ const (
 	prefix        = "github.com/vladopajic/go-test-coverage/v2"
 	coverFilename = "pkg/testcoverage/coverage/cover.go"
 
-	rootDir = "../../../"
+	sourceDir = "../../../"
 )
 
 func Test_GenerateCoverageStats(t *testing.T) {
@@ -42,16 +42,16 @@ func Test_GenerateCoverageStats(t *testing.T) {
 
 	// should get error parsing invalid profile file
 	stats, err = GenerateCoverageStats(Config{
-		Profiles: []string{profileNOK},
-		RootDir:  rootDir,
+		Profiles:  []string{profileNOK},
+		SourceDir: sourceDir,
 	})
 	assert.Error(t, err)
 	assert.Empty(t, stats)
 
 	// should be okay to read valid profile
 	stats1, err := GenerateCoverageStats(Config{
-		Profiles: []string{profileOK},
-		RootDir:  rootDir,
+		Profiles:  []string{profileOK},
+		SourceDir: sourceDir,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, stats1)
@@ -60,7 +60,7 @@ func Test_GenerateCoverageStats(t *testing.T) {
 	stats2, err := GenerateCoverageStats(Config{
 		Profiles:     []string{profileOK},
 		ExcludePaths: []string{`cover\.go$`},
-		RootDir:      rootDir,
+		SourceDir:    sourceDir,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, stats2)
@@ -69,8 +69,8 @@ func Test_GenerateCoverageStats(t *testing.T) {
 
 	// should have total coverage because of second profile
 	stats3, err := GenerateCoverageStats(Config{
-		Profiles: []string{profileOK, profileOKFull},
-		RootDir:  rootDir,
+		Profiles:  []string{profileOK, profileOKFull},
+		SourceDir: sourceDir,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, stats3)
@@ -78,8 +78,8 @@ func Test_GenerateCoverageStats(t *testing.T) {
 
 	// should not have `badge/generate.go` in statistics because it has no statements
 	stats4, err := GenerateCoverageStats(Config{
-		Profiles: []string{profileOKNoStatements},
-		RootDir:  rootDir,
+		Profiles:  []string{profileOKNoStatements},
+		SourceDir: sourceDir,
 	})
 	assert.NoError(t, err)
 	assert.Len(t, stats4, 1)


### PR DESCRIPTION
this PR adds new github action property `source-dir` which can be used to point to location of source files relative from root.

closes: https://github.com/vladopajic/go-test-coverage/issues/66