### PR TITLE
fix(coverage): improved go.mod file search

### DIFF
--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -208,7 +208,7 @@ func listAllFiles(rootDir string) []fileInfo {
 		return nil
 	})
 	if err != nil { // coverage-ignore
-		logger.L.Error().Err(err).Msg("listing go files")
+		logger.L.Error().Err(err).Msg("listing files (.go files search)")
 	}
 
 	return files

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -6,6 +6,7 @@ var (
 	FindFuncsAndBlocks = findFuncsAndBlocks
 	ParseProfiles      = parseProfiles
 	SumCoverage        = sumCoverage
+	FindGoModFile      = findGoModFile
 )
 
 type Extent = extent

--- a/pkg/testcoverage/coverage/module.go
+++ b/pkg/testcoverage/coverage/module.go
@@ -17,7 +17,7 @@ func findModuleDirective(rootDir string) string {
 		return ""
 	}
 
-	logger.L.Debug().Str("file", goModFile).Msg("found go.mod file")
+	logger.L.Debug().Str("file", goModFile).Msg("go.mod file found")
 
 	module := readModuleDirective(goModFile)
 	if module == "" { // coverage-ignore

--- a/pkg/testcoverage/coverage/module.go
+++ b/pkg/testcoverage/coverage/module.go
@@ -12,9 +12,11 @@ import (
 func findModuleDirective(rootDir string) string {
 	goModFile := findGoModFile(rootDir)
 	if goModFile == "" {
-		logger.L.Warn().Str("dir", rootDir).Msg("could not find go.mod file in root dir")
+		logger.L.Warn().Str("dir", rootDir).Msg("go.mod file not found in root directory (consider setting up source dir)")
 		return ""
 	}
+
+	logger.L.Debug().Str("file", goModFile).Msg("found go.mod file")
 
 	module := readModuleDirective(goModFile)
 	if module == "" { // coverage-ignore
@@ -27,23 +29,60 @@ func findModuleDirective(rootDir string) string {
 }
 
 func findGoModFile(rootDir string) string {
-	var goModFile string
+	goModFile := findGoModFromRoot(rootDir)
+	if goModFile != "" {
+		return goModFile
+	}
 
-	//nolint:errcheck // error ignored because there is fallback mechanism for finding files
-	filepath.Walk(rootDir, func(file string, info os.FileInfo, err error) error {
+	// fallback to find first go mod file wherever it may be
+	// not really sure if we really need this ???
+	return findGoModWithWalk(rootDir)
+}
+
+func findGoModWithWalk(rootDir string) string { // coverage-ignore
+	var goModFiles []string
+
+	err := filepath.Walk(rootDir, func(file string, info os.FileInfo, err error) error {
 		if err != nil { // coverage-ignore
 			return err
 		}
 
 		if info.Name() == "go.mod" {
-			goModFile = file
-			return filepath.SkipAll
+			goModFiles = append(goModFiles, file)
 		}
 
 		return nil
 	})
+	if err != nil {
+		logger.L.Error().Err(err).Msg("listing files (go.mod search)")
+	}
 
-	return goModFile
+	if len(goModFiles) == 0 {
+		logger.L.Warn().Msg("go.mod file not found via walk method")
+		return ""
+	}
+	if len(goModFiles) > 1 {
+		logger.L.Warn().Msg("found multiple go.mod files via walk method")
+		return ""
+	}
+
+	return goModFiles[0]
+}
+
+func findGoModFromRoot(rootDir string) string {
+	files, err := os.ReadDir(rootDir)
+	if err != nil { // coverage-ignore
+		logger.L.Error().Err(err).Msg("reading directory")
+		return ""
+	}
+
+	for _, info := range files {
+		if info.Name() == "go.mod" {
+			return filepath.Join(rootDir, info.Name())
+		}
+	}
+
+	return ""
 }
 
 func readModuleDirective(filename string) string {

--- a/pkg/testcoverage/coverage/module.go
+++ b/pkg/testcoverage/coverage/module.go
@@ -12,7 +12,8 @@ import (
 func findModuleDirective(rootDir string) string {
 	goModFile := findGoModFile(rootDir)
 	if goModFile == "" {
-		logger.L.Warn().Str("dir", rootDir).Msg("go.mod file not found in root directory (consider setting up source dir)")
+		logger.L.Warn().Str("dir", rootDir).
+			Msg("go.mod file not found in root directory (consider setting up source dir)")
 		return ""
 	}
 
@@ -61,6 +62,7 @@ func findGoModWithWalk(rootDir string) string { // coverage-ignore
 		logger.L.Warn().Msg("go.mod file not found via walk method")
 		return ""
 	}
+
 	if len(goModFiles) > 1 {
 		logger.L.Warn().Msg("found multiple go.mod files via walk method")
 		return ""

--- a/pkg/testcoverage/coverage/module_test.go
+++ b/pkg/testcoverage/coverage/module_test.go
@@ -13,5 +13,5 @@ func Test_FindGoModFile(t *testing.T) {
 	t.Parallel()
 
 	assert.Empty(t, FindGoModFile(""))
-	assert.Equal(t, path.NormalizeForTool("../../../go.mod"), FindGoModFile("../../../"))
+	assert.Equal(t, "../../../go.mod", path.NormalizeForTool(FindGoModFile("../../../")))
 }

--- a/pkg/testcoverage/coverage/module_test.go
+++ b/pkg/testcoverage/coverage/module_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/vladopajic/go-test-coverage/v2/pkg/testcoverage/coverage"
+	"github.com/vladopajic/go-test-coverage/v2/pkg/testcoverage/path"
 )
 
 func Test_FindGoModFile(t *testing.T) {
 	t.Parallel()
 
 	assert.Empty(t, FindGoModFile(""))
-	assert.Equal(t, "../../../go.mod", FindGoModFile("../../../"))
+	assert.Equal(t, path.NormalizeForTool("../../../go.mod"), FindGoModFile("../../../"))
 }

--- a/pkg/testcoverage/coverage/module_test.go
+++ b/pkg/testcoverage/coverage/module_test.go
@@ -1,0 +1,16 @@
+package coverage_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/vladopajic/go-test-coverage/v2/pkg/testcoverage/coverage"
+)
+
+func Test_FindGoModFile(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, FindGoModFile(""))
+	assert.Equal(t, "../../../go.mod", FindGoModFile("../../../"))
+}


### PR DESCRIPTION
searching for `go.mod` with `filepath.Walk` is not ideal as it is depth first search, which may return`go.mod` files in directories that are lexicographical before `go.mod` file.

with this pr, `go.mod` will be searched in root directory and `filepath.Walk`  will be used as fallback.

should fix: #190
