### PR TITLE
fix: correct example config to use `null` and add validation test

### DIFF
--- a/.testcoverage.example.yml
+++ b/.testcoverage.example.yml
@@ -60,7 +60,7 @@ diff:
   # Allowed threshold for the test coverage difference (in percentage) 
   # between the feature branch and the base branch.
   #
-  # By default, this is disabled (set to nil). Valid values range from 
+  # By default, this is disabled (set to null). Valid values range from 
   # -100.0 to +100.0.
   #
   # Example: 
@@ -68,4 +68,4 @@ diff:
   #   less than 0.5% more coverage than the base.
   #
   #   If set to -0.5, the check allows up to 0.5% less coverage than the base.
-  threshold: nil
+  threshold: null

--- a/pkg/testcoverage/config_test.go
+++ b/pkg/testcoverage/config_test.go
@@ -213,6 +213,15 @@ func Test_ConfigFromFile(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, savedCfg, cfg)
 	})
+
+	t.Run("example file", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := Config{}
+		filename := "../../.testcoverage.example.yml"
+		err := ConfigFromFile(&cfg, filename)
+		assert.NoError(t, err)
+	})
 }
 
 func TestConfigYamlParse(t *testing.T) {


### PR DESCRIPTION
YAML treats `nil` as a plain string, so the action will receive an unexpected type and fail.

To ensure correctness and adhere to the standard, it's better to use `null`.

Fix #208 