### PR TITLE
ci(lint): fix govulen check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,17 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      
       - name: go mod tidy check
         uses: katexochen/go-tidy-check@v2
+      
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.6.1 # LINT_VERSION: update version in other places
+      
       - id: govulncheck
         uses: golang/govulncheck-action@v1
+        with:
+          repo-checkout: false
+          go-package: ./...


### PR DESCRIPTION
`govulen` check was failing on checkout, but since it is not needed option is disabled.