### PR TITLE
chore(docker): no attestation on push

### DIFF
--- a/.github/workflows/action-docker-test.yml
+++ b/.github/workflows/action-docker-test.yml
@@ -30,6 +30,8 @@ jobs:
         platforms: linux/arm64,linux/amd64
         build-args: |
           VERSION=dev
+        provenance: false
+        sbom: false
         tags: |
           ghcr.io/vladopajic/go-test-coverage:dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
           build-args: |
             VERSION=${{ env.RELEASE_VERSION }}
           platforms: linux/arm64,linux/amd64
+          provenance: false
+          sbom: false
           tags: |
             ghcr.io/vladopajic/go-test-coverage:${{ env.RELEASE_VERSION }}
             ghcr.io/vladopajic/go-test-coverage:${{ steps.majorver.outputs.major-tag }}


### PR DESCRIPTION
pushing docker images without attestations. 

this could be reason for "manifest unknown" issues: #245
