### PR TITLE
chore(docs): update action link in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ steps:
     run: go test ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./...
 
   - name: check test coverage
-    uses: vladopajic/go-test-coverage/action/source@v2
+    uses: vladopajic/go-test-coverage@v2
     with:
       config: ./.testcoverage.yml
 ```


### PR DESCRIPTION
assuming docker pull issues have been resolved, reverting #249 to use default action in example