### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
-on: [push]
+on:
+  push:
+    tags:
+      - "v[0-9]+\\.[0-9]+\\.[0-9]+"
 jobs:
   release:
     permissions:
@@ -13,20 +16,23 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: set RELEASE_VERSION ENV var
-        run: echo "RELEASE_VERSION=v2.18.2" >> $GITHUB_ENV
+      - name: set RELEASE_VERSION env
+        run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
       
-      - name:
+      - name: set MAJOR_VERSION env
         run: |
           MAJOR_VERSION="${RELEASE_VERSION:0:2}"
           echo "MAJOR_VERSION=$MAJOR_VERSION" >> $GITHUB_ENV
 
+      - name: echo env var
+        run: |
+          echo "Release version: ${{ env.RELEASE_VERSION }}"
+          echo "Major version: ${{ env.MAJOR_VERSION }}"
+
       - name: ensure image version is set to release version
         run: |
           image=$(yq '.runs.image' action.yml)
-          echo "Image: $image"
-          echo "Release version: ${{ env.RELEASE_VERSION }}"
-          echo "Major version: ${{ env.MAJOR_VERSION }}"
+          echo "Image version: $image"
           [[ "$image" == *"${{ env.RELEASE_VERSION }}" ]]
 
       - name: login to GitHub container registry
@@ -36,7 +42,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
+      - name: set up docker buildx
         uses: docker/setup-buildx-action@v3.12.0
         with:
           use: true


### PR DESCRIPTION
- `actions/publish-action@v0.4.0` was used for making `major version` string, which could be created using first two letters from release version. 
could be error prone once release goes above v9.0.0, but this should not happen in near future.