### PR TITLE
chore: improvements

### DIFF
--- a/pkg/testcoverage/config.go
+++ b/pkg/testcoverage/config.go
@@ -86,7 +86,7 @@ func (c Config) Redacted() Config {
 
 func (c Config) Validate() error {
 	validateRegexp := func(s string) error {
-		_, err := regexp.Compile("(?i)" + s)
+		_, err := regexp.Compile(s)
 		return err //nolint:wrapcheck // error is wrapped at level above
 	}
 

--- a/pkg/testcoverage/coverage/types.go
+++ b/pkg/testcoverage/coverage/types.go
@@ -19,8 +19,12 @@ type Stats struct {
 	AnnotationsWithoutComments []int
 }
 
-func (s Stats) UncoveredLinesCount() int {
+func (s Stats) UncoveredStmtCount() int {
 	return int(s.Total - s.Covered)
+}
+
+func (s Stats) UncoveredLinesCount() int {
+	return len(s.UncoveredLines)
 }
 
 func (s Stats) CoveredPercentage() int {

--- a/pkg/testcoverage/coverage/types.go
+++ b/pkg/testcoverage/coverage/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -50,6 +51,12 @@ func (s Stats) Str() string {
 	}
 
 	return fmt.Sprintf("%.1f%% (%d/%d)", s.CoveredPercentageF(), s.Covered, s.Total)
+}
+
+func SortStatsByName(stats []Stats) {
+	slices.SortFunc(stats, func(a, b Stats) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 }
 
 func StatsSearchMap(stats []Stats) map[string]Stats {

--- a/pkg/testcoverage/helpers_test.go
+++ b/pkg/testcoverage/helpers_test.go
@@ -31,6 +31,21 @@ func copyStats(s []coverage.Stats) []coverage.Stats {
 	return mergeStats(make([]coverage.Stats, 0), s)
 }
 
+func makeStats(name string, total, covered int64) coverage.Stats {
+	uncovered := int(total - covered)
+	lines := make([]int, uncovered)
+	for i := range uncovered {
+		lines[i] = i + 1
+	}
+
+	return coverage.Stats{
+		Name:           name,
+		Total:          total,
+		Covered:        covered,
+		UncoveredLines: lines,
+	}
+}
+
 func randStats(localPrefix string, minc, maxc int) []coverage.Stats {
 	const count = 100
 

--- a/pkg/testcoverage/helpers_test.go
+++ b/pkg/testcoverage/helpers_test.go
@@ -33,6 +33,7 @@ func copyStats(s []coverage.Stats) []coverage.Stats {
 
 func makeStats(name string, total, covered int64) coverage.Stats {
 	uncovered := int(total - covered)
+
 	lines := make([]int, uncovered)
 	for i := range uncovered {
 		lines[i] = i + 1

--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -61,6 +61,8 @@ func reportIssuesForHuman(w io.Writer, coverageStats []coverage.Stats) {
 
 	fmt.Fprintf(w, "\n  below threshold:\tcoverage:\tthreshold:")
 
+	coverage.SortStatsByName(coverageStats)
+
 	for _, stats := range coverageStats {
 		fmt.Fprintf(w, "\n  %s\t%s\t%d%%", stats.Name, stats.Str(), stats.Threshold)
 	}
@@ -78,6 +80,8 @@ func reportUncoveredLines(w io.Writer, result AnalyzeResult) {
 
 	fmt.Fprintf(tabber, "\nFiles with uncovered lines:")
 	fmt.Fprintf(tabber, "\n  file:\tcoverage:\tuncovered lines:")
+
+	coverage.SortStatsByName(result.FilesWithUncoveredLines)
 
 	for _, stats := range result.FilesWithUncoveredLines {
 		if len(stats.UncoveredLines) > 0 {
@@ -100,6 +104,8 @@ func reportMissingExplanations(w io.Writer, result AnalyzeResult) {
 
 	fmt.Fprintf(tabber, "\nFiles with missing explanation for coverage-ignore annotation:")
 	fmt.Fprintf(tabber, "\n  file:\tline numbers:")
+
+	coverage.SortStatsByName(result.FilesWithMissingExplanations)
 
 	for _, stats := range result.FilesWithMissingExplanations {
 		if len(stats.AnnotationsWithoutComments) == 0 { // coverage-ignore
@@ -162,6 +168,10 @@ func ReportForGithubAction(w io.Writer, result AnalyzeResult) {
 	reportError := func(title, msg string) {
 		fmt.Fprintf(out, "::error title=%s::%s\n", title, msg)
 	}
+
+	coverage.SortStatsByName(result.FilesBelowThreshold)
+	coverage.SortStatsByName(result.PackagesBelowThreshold)
+	coverage.SortStatsByName(result.FilesWithMissingExplanations)
 
 	for _, stats := range result.FilesBelowThreshold {
 		title := "File test coverage below threshold"

--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -146,7 +146,7 @@ func reportDiff(w io.Writer, result AnalyzeResult) {
 		}
 
 		c := d.Current
-		fmt.Fprintf(tabber, "\n  %s\t%3d\t%s\t%s", c.Name, c.UncoveredLinesCount(), c.Str(), baseStr)
+		fmt.Fprintf(tabber, "\n  %s\t%3d\t%s\t%s", c.Name, c.UncoveredStmtCount(), c.Str(), baseStr)
 	}
 
 	fmt.Fprintf(tabber, "\n")

--- a/pkg/testcoverage/report.go
+++ b/pkg/testcoverage/report.go
@@ -146,7 +146,7 @@ func reportDiff(w io.Writer, result AnalyzeResult) {
 		}
 
 		c := d.Current
-		fmt.Fprintf(tabber, "\n  %s\t%3d\t%s\t%s", c.Name, c.UncoveredStmtCount(), c.Str(), baseStr)
+		fmt.Fprintf(tabber, "\n  %s\t%3d\t%s\t%s", c.Name, c.UncoveredLinesCount(), c.Str(), baseStr)
 	}
 
 	fmt.Fprintf(tabber, "\n")

--- a/pkg/testcoverage/report_test.go
+++ b/pkg/testcoverage/report_test.go
@@ -114,10 +114,10 @@ func Test_ReportForHumanDiff(t *testing.T) {
 		stats := randStats(prefix, 10, 100)
 		base := copyStats(stats)
 
-		stats = append(stats, coverage.Stats{Name: "foo", Total: 9, Covered: 8})
-		stats = append(stats, coverage.Stats{Name: "foo-new", Total: 9, Covered: 8})
+		stats = append(stats, makeStats("foo", 9, 8))
+		stats = append(stats, makeStats("foo-new", 9, 8))
 
-		base = append(base, coverage.Stats{Name: "foo", Total: 10, Covered: 10})
+		base = append(base, makeStats("foo", 10, 10))
 
 		buf := &bytes.Buffer{}
 		cfg := Config{}
@@ -132,8 +132,8 @@ func Test_ReportForHumanDiff(t *testing.T) {
 	t.Run("diff - threshold failed", func(t *testing.T) {
 		t.Parallel()
 
-		base := []coverage.Stats{{Name: "foo", Total: 10, Covered: 1}}
-		stats := []coverage.Stats{{Name: "foo", Total: 10, Covered: 8}}
+		base := []coverage.Stats{makeStats("foo", 10, 1)}
+		stats := []coverage.Stats{makeStats("foo", 10, 8)}
 
 		buf := &bytes.Buffer{}
 		cfg := Config{
@@ -150,8 +150,8 @@ func Test_ReportForHumanDiff(t *testing.T) {
 	t.Run("diff - threshold pass", func(t *testing.T) {
 		t.Parallel()
 
-		base := []coverage.Stats{{Name: "foo", Total: 10, Covered: 1}}
-		stats := []coverage.Stats{{Name: "foo", Total: 10, Covered: 8}}
+		base := []coverage.Stats{makeStats("foo", 10, 1)}
+		stats := []coverage.Stats{makeStats("foo", 10, 8)}
 
 		buf := &bytes.Buffer{}
 		cfg := Config{
@@ -168,8 +168,8 @@ func Test_ReportForHumanDiff(t *testing.T) {
 	t.Run("diff - negative threshold pass", func(t *testing.T) {
 		t.Parallel()
 
-		base := []coverage.Stats{{Name: "foo", Total: 100, Covered: 100}}
-		stats := []coverage.Stats{{Name: "foo", Total: 100, Covered: 90}}
+		base := []coverage.Stats{makeStats("foo", 100, 100)}
+		stats := []coverage.Stats{makeStats("foo", 100, 90)}
 
 		buf := &bytes.Buffer{}
 		cfg := Config{

--- a/pkg/testcoverage/report_test.go
+++ b/pkg/testcoverage/report_test.go
@@ -89,7 +89,6 @@ func Test_ReportForHuman(t *testing.T) {
 	})
 }
 
-//nolint:dupl // relax
 func Test_ReportForHumanDiff(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/testcoverage/types.go
+++ b/pkg/testcoverage/types.go
@@ -112,13 +112,13 @@ func calculateStatsDiff(current, base []coverage.Stats) []FileCoverageDiff {
 	baseSearchMap := coverage.StatsSearchMap(base)
 
 	for _, s := range current {
-		sul := s.UncoveredLinesCount()
+		sul := s.UncoveredStmtCount()
 		if sul == 0 {
 			continue
 		}
 
 		if b, found := baseSearchMap[s.Name]; found {
-			if sul != b.UncoveredLinesCount() {
+			if sul != b.UncoveredStmtCount() {
 				res = append(res, FileCoverageDiff{Current: s, Base: &b})
 			}
 		} else {


### PR DESCRIPTION
- diff currently reported number of uncovered statements, but label was "uncovered lines". now tool will correctly show number of uncovered lines.
- in go files are case case-sensitive, therefore regexp should be case sensitive
- stable report ordering 