### PR TITLE
fix(coverage): file search should be preceded by `/`

### DIFF
--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -221,7 +221,7 @@ func findFilePathMatchingSearch(files *[]fileInfo, search string) string {
 	// matches files "bar/foo.go", "bar/baz/foo.go" and "foo.go", but it's the
 	// best match with "foo.go".
 	bestMatch := func() int {
-		fIndex, searchPos := -1, math.MaxInt64
+		bestIndex, bestSearchPos := -1, math.MaxInt64
 
 		for i, f := range *files {
 			pos := strings.LastIndex(f.name, search)
@@ -230,7 +230,7 @@ func findFilePathMatchingSearch(files *[]fileInfo, search string) string {
 			}
 
 			if pos == 0 { // 100% match
-				return fIndex
+				return bestIndex
 			}
 
 			// if not exact match, it must be preceded by "/"
@@ -240,13 +240,13 @@ func findFilePathMatchingSearch(files *[]fileInfo, search string) string {
 			}
 
 			// save as the best match for this file
-			if searchPos > pos {
-				searchPos = pos
-				fIndex = i
+			if bestSearchPos > pos {
+				bestSearchPos = pos
+				bestIndex = i
 			}
 		}
 
-		return fIndex
+		return bestIndex
 	}
 
 	i := bestMatch()

--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -229,13 +229,20 @@ func findFilePathMatchingSearch(files *[]fileInfo, search string) string {
 				continue
 			}
 
+			if pos == 0 { // 100% match
+				return fIndex
+			}
+
+			// if not exact match, it must be preceded by "/"
+			// because "pkg/foo.go" should never match "test-pkg/foo.go"
+			if f.name[pos-1] != '/' {
+				continue
+			}
+
+			// save as the best match for this file
 			if searchPos > pos {
 				searchPos = pos
 				fIndex = i
-
-				if searchPos == 0 { // 100% match
-					return fIndex
-				}
 			}
 		}
 

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -227,6 +227,14 @@ func Test_findFuncs(t *testing.T) {
 	}, blocks)
 }
 
+func Test_findFilePathMatchingSearch(t *testing.T) {
+	t.Parallel()
+
+	files := []FileInfo{NewFileInfo("test-pkg/foo.go")}
+	result := FindFilePathMatchingSearch(&files, "pkg/foo.go")
+	assert.Empty(t, result)
+}
+
 func Test_sumCoverage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -1,18 +1,20 @@
 package coverage
 
 var (
-	FindFileCreator             = findFileCreator
-	FindAnnotations             = findAnnotations
-	FindFuncsAndBlocks          = findFuncsAndBlocks
-	ParseProfiles               = parseProfiles
-	SumCoverage                 = sumCoverage
-	FindGoModFile               = findGoModFile
-	PluckStartLine              = pluckStartLine
+	FindFileCreator            = findFileCreator
+	FindAnnotations            = findAnnotations
+	FindFuncsAndBlocks         = findFuncsAndBlocks
+	ParseProfiles              = parseProfiles
+	SumCoverage                = sumCoverage
+	FindGoModFile              = findGoModFile
+	PluckStartLine             = pluckStartLine
 	FindFilePathMatchingSearch = findFilePathMatchingSearch
 )
 
-type Extent = extent
-type FileInfo = fileInfo
+type (
+	Extent   = extent
+	FileInfo = fileInfo
+)
 
 func NewFileInfo(name string) fileInfo {
 	return fileInfo{name: name}

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -1,13 +1,19 @@
 package coverage
 
 var (
-	FindFileCreator    = findFileCreator
-	FindAnnotations    = findAnnotations
-	FindFuncsAndBlocks = findFuncsAndBlocks
-	ParseProfiles      = parseProfiles
-	SumCoverage        = sumCoverage
-	FindGoModFile      = findGoModFile
-	PluckStartLine     = pluckStartLine
+	FindFileCreator             = findFileCreator
+	FindAnnotations             = findAnnotations
+	FindFuncsAndBlocks          = findFuncsAndBlocks
+	ParseProfiles               = parseProfiles
+	SumCoverage                 = sumCoverage
+	FindGoModFile               = findGoModFile
+	PluckStartLine              = pluckStartLine
+	FindFilePathMatchingSearch = findFilePathMatchingSearch
 )
 
 type Extent = extent
+type FileInfo = fileInfo
+
+func NewFileInfo(name string) fileInfo {
+	return fileInfo{name: name}
+}


### PR DESCRIPTION
fix case when file search for `pkg/foo.go` can match `test-pkg/foo.go`