### PR TITLE
fix(coverage): wrong index returned in #308

### DIFF
--- a/.github/.testcoverage-local.yml
+++ b/.github/.testcoverage-local.yml
@@ -9,6 +9,6 @@ override:
   threshold: 43
 - path: path/path.go$           ## requires windows to be tested
   threshold: 66
-# exclude:
-#   paths:
-#     - main\.go$
+exclude:
+  paths:
+    - main\.go$

--- a/.github/.testcoverage-local.yml
+++ b/.github/.testcoverage-local.yml
@@ -9,6 +9,6 @@ override:
   threshold: 43
 - path: path/path.go$           ## requires windows to be tested
   threshold: 66
-exclude:
-  paths:
-    - main\.go$
+# exclude:
+#   paths:
+#     - main\.go$

--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -230,7 +230,7 @@ func findFilePathMatchingSearch(files *[]fileInfo, search string) string {
 			}
 
 			if pos == 0 { // 100% match
-				return bestIndex
+				return i
 			}
 
 			// if not exact match, it must be preceded by "/"

--- a/pkg/testcoverage/coverage/cover.go
+++ b/pkg/testcoverage/coverage/cover.go
@@ -124,7 +124,7 @@ func findFiles(profiles []*cover.Profile, rootDir string) (map[string]fileInfo, 
 	return result, nil
 }
 
-func findFileCreator(rootDir string) func(file string) (string, string, bool) {
+func findFileCreator(rootDirUser string) func(file string) (string, string, bool) {
 	cache := make(map[string]*build.Package)
 	findBuildImport := func(file string) (string, string, bool) {
 		dir, file := filepath.Split(file)
@@ -148,8 +148,8 @@ func findFileCreator(rootDir string) func(file string) (string, string, bool) {
 		return file, noPrefixName, err == nil
 	}
 
-	rootDir = defaultRootDir(rootDir)
-	prefix := findModuleDirective(rootDir)
+	prefix, rootDir := findModuleDirective(defaultRootDir(rootDirUser))
+
 	files := listAllFiles(rootDir)
 	findFsSearch := func(file string) (string, string, bool) {
 		noPrefixName := stripPrefix(file, prefix)

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -233,6 +233,14 @@ func Test_findFilePathMatchingSearch(t *testing.T) {
 	files := []FileInfo{NewFileInfo("test-pkg/foo.go")}
 	result := FindFilePathMatchingSearch(&files, "pkg/foo.go")
 	assert.Empty(t, result)
+
+	files = []FileInfo{NewFileInfo("baz/foo.go"), NewFileInfo("bar/baz/foo.go")}
+	result = FindFilePathMatchingSearch(&files, "foo.go")
+	assert.Equal(t, "baz/foo.go", result)
+
+	files = []FileInfo{NewFileInfo("baz/foo.go"), NewFileInfo("bar/baz/foo.go"), NewFileInfo("foo.go")}
+	result = FindFilePathMatchingSearch(&files, "foo.go")
+	assert.Equal(t, "foo.go", result)
 }
 
 func Test_sumCoverage(t *testing.T) {

--- a/pkg/testcoverage/coverage/cover_test.go
+++ b/pkg/testcoverage/coverage/cover_test.go
@@ -241,6 +241,11 @@ func Test_findFilePathMatchingSearch(t *testing.T) {
 	files = []FileInfo{NewFileInfo("baz/foo.go"), NewFileInfo("bar/baz/foo.go"), NewFileInfo("foo.go")}
 	result = FindFilePathMatchingSearch(&files, "foo.go")
 	assert.Equal(t, "foo.go", result)
+
+	// exact match file is the first element (bestIndex is -1 when 100% match is found)
+	files = []FileInfo{NewFileInfo("foo.go"), NewFileInfo("baz/foo.go")}
+	result = FindFilePathMatchingSearch(&files, "foo.go")
+	assert.Equal(t, "foo.go", result)
 }
 
 func Test_sumCoverage(t *testing.T) {

--- a/pkg/testcoverage/coverage/export_test.go
+++ b/pkg/testcoverage/coverage/export_test.go
@@ -17,5 +17,5 @@ type (
 )
 
 func NewFileInfo(name string) fileInfo {
-	return fileInfo{name: name}
+	return fileInfo{name: name, path: name}
 }

--- a/pkg/testcoverage/coverage/module.go
+++ b/pkg/testcoverage/coverage/module.go
@@ -9,25 +9,30 @@ import (
 	"github.com/vladopajic/go-test-coverage/v2/pkg/testcoverage/logger"
 )
 
-func findModuleDirective(rootDir string) string {
+func findModuleDirective(rootDir string) (module string, dir string) {
+	logger.L.Debug().Str("root dir", rootDir).Msg("searching for go.mod")
+
 	goModFile := findGoModFile(rootDir)
 	if goModFile == "" {
 		logger.L.Warn().Str("dir", rootDir).
 			Msg("go.mod file not found in root directory (consider setting up source dir)")
 
-		return ""
+		return "", rootDir
 	}
 
 	logger.L.Debug().Str("file", goModFile).Msg("go.mod file found")
 
-	module := readModuleDirective(goModFile)
+	module = readModuleDirective(goModFile)
 	if module == "" { // coverage-ignore
 		logger.L.Warn().Msg("`module` directive not found")
 	}
 
-	logger.L.Debug().Str("module", module).Msg("using module directive")
+	dir = strings.TrimSuffix(goModFile, "go.mod")
 
-	return module
+	logger.L.Debug().Str("module", module).Msg("using module directive")
+	logger.L.Debug().Str("rootdir", dir).Msg("root dir")
+
+	return module, dir
 }
 
 func findGoModFile(rootDir string) string {

--- a/pkg/testcoverage/coverage/module.go
+++ b/pkg/testcoverage/coverage/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vladopajic/go-test-coverage/v2/pkg/testcoverage/logger"
 )
 
+//nolint:nonamedreturns // relax
 func findModuleDirective(rootDir string) (module string, dir string) {
 	logger.L.Debug().Str("root dir", rootDir).Msg("searching for go.mod")
 
@@ -27,7 +28,7 @@ func findModuleDirective(rootDir string) (module string, dir string) {
 		logger.L.Warn().Msg("`module` directive not found")
 	}
 
-	dir = strings.TrimSuffix(goModFile, "go.mod")
+	dir = filepath.Dir(goModFile)
 
 	logger.L.Debug().Str("module", module).Msg("using module directive")
 	logger.L.Debug().Str("rootdir", dir).Msg("root dir")


### PR DESCRIPTION
- pr 308 returned wrong index should be `i` instead of `bestIndex`.
- made additional improvements: `rootDir` will be used after `go.mod` is found
