### PR TITLE
chore(lint): drop the dead wsl setting, enable new v2.11 linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,12 @@
 version: "2"
 linters:
   enable:
+    - arangolint
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - containedctx
     - contextcheck
     - copyloopvar
@@ -40,6 +42,7 @@ linters:
     - gomodguard
     - goprintffuncname
     - gosec
+    - gosmopolitan
     - grouper
     - iface
     - importas
@@ -54,6 +57,7 @@ linters:
     - mirror
     - misspell
     - mnd
+    - musttag
     - nakedret
     - nestif
     - nilerr
@@ -73,17 +77,21 @@ linters:
     - reassign
     - recvcheck
     - revive
+    - rowserrcheck
     - sloglint
+    - spancheck
     - sqlclosecheck
     - staticcheck
     - tagalign
     - tagliatelle
+    - testableexamples
     - testifylint
     - testpackage
     - thelper
     - tparallel
     - unconvert
     - unparam
+    - unqueryvet
     - usestdlibvars
     - usetesting
     - wastedassign
@@ -144,8 +152,6 @@ linters:
       enable-all: true
     unparam:
       check-exported: true
-    wsl:
-      force-err-cuddling: true
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
Fixes #283

Two changes to `.golangci.yml`, following the v2.6.1 → v2.11.3 bump in #273:

**1. Removed the dead `settings.wsl` block.** `wsl` is deprecated in v2.11 and is not enabled here —
the enabled linter is `wsl_v5`, which does not read that key. So `force-err-cuddling: true` has been
a no-op; the cuddling behaviour you actually get comes from `wsl_v5` defaults (that's the check that
fired on my #330, so it demonstrably works without this setting).

**2. Enabled the linters added between v2.6 and v2.11 that pass on the current tree with zero findings:**
`arangolint`, `canonicalheader`, `gosmopolitan`, `musttag`, `rowserrcheck`, `spancheck`,
`testableexamples`, `unqueryvet` — keeping the config's "enable everything reasonable" style.

**Deliberately not enabled** (each produces findings on the current tree, so enabling them belongs in
its own PR with the corresponding code changes, if you want them at all):

| linter | findings | note |
|---|---|---|
| `modernize` | 10 | mostly `strings.CutPrefix` / `fmt.Appendf` / `ptr(x)`→`new(x)` suggestions |
| `noinlineerr` | 3 | forbids `if err := ...; err != nil` — a style call I didn't want to make for you |
| `godoclint` | 1 | doc-comment formatting |

Happy to follow up with a `modernize` cleanup PR if you'd take it.

Verified with `golangci/golangci-lint:v2.11.3` in docker: `golangci-lint run` on this branch reports
0 issues (the only local noise was `gofmt` on my Windows checkout's CRLF, which is not part of the diff —
the PR touches only `.golangci.yml`).

AI-assisted (LLM used for drafting); config runs above executed and reviewed by me.
